### PR TITLE
Remove elements and convert to onEvent

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,6 @@ const generic = {
 
 const autoCapture = {
     event: 'properties.$event_type',
-    'properties.elements': 'properties.$elements',
 }
 
 const eventToMapping = {
@@ -220,9 +219,9 @@ export async function setupPlugin({ config, global, jobs }) {
     global.dataPlaneUrl = config.dataPlaneUrl
 }
 
-export async function exportEvents(events, { global }) {
+export async function onEvent(event, { global }) {
     const payload = {
-        batch: events.map(constructRudderPayload),
+        ...constructRudderPayload(event),
         sentAt: new Date().toISOString(),
     }
 
@@ -234,7 +233,6 @@ export async function exportEvents(events, { global }) {
         body: JSON.stringify(payload),
         method: 'POST',
     })
-    console.log(`Successfully uploaded ${payload.batch.length} events to RudderStack`)
 }
 
 function constructRudderPayload(event) {

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ export async function setupPlugin({ config, global, jobs }) {
 
 export async function onEvent(event, { global }) {
     const payload = {
-        ...constructRudderPayload(event),
+        batch: [constructRudderPayload(event)],
         sentAt: new Date().toISOString(),
     }
 


### PR DESCRIPTION
We're moving away from 
1. exporting elements as these are PostHog custom encoding of the DOM, which doesn't much make sense outside without our queries/re-encoding. It's also expensive to handle and send.
2. exportEvents function and buffer - instead we'll either have batch exports (hourly or daily) or webhooks style where each event is sent directly. I'm assuming Rudderstack belongs in the webhooks category, so you get the data immediately.


Note haven't tested this yet - wanted to confirm the changes make sense first and then will set-up local testing.